### PR TITLE
Add fast_p Scoring + CPU build cache in Eval to shorten build time

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,15 +94,22 @@ python3 scripts/generate_and_eval_single_sample.py dataset_src="huggingface" lev
 
 ```
 # 1. Generate responses and store kernels locally to runs/{run_name} directory
-python3 scripts/generate_samples.py run_name="test_hf_level_1" dataset_src="huggingface" level="1" num_workers=50 server_type="deepseek" model_name="deepseek-coder" temperature=0
+python3 scripts/generate_samples.py run_name=test_hf_level_1 dataset_src=huggingface level=1 num_workers=50 server_type=deepseek model_name=deepseek-chat temperature=0
 
 # 2. Evaluate on all generated kernels in runs/{run_name} directory
-python3 scripts/eval_from_generations.py level=1 run_name="test_hf_level_1" dataset_src="local" level="1" num_gpu_devices=8 timeout=300
+python3 scripts/eval_from_generations.py run_name=test_hf_level_1 dataset_src=local level=1 num_gpu_devices=8 timeout=300
+
+# If you like to speedup evaluation, you can use parallelize compilation on CPUs before getting to evluation on GPUs
+# add build_cache=True and num_cpu_workers=<num_cpu_workers> to the command
+```
+### Analyze the eval results to compute Benchmark Performance
+We provide `scripts/benchmark_eval_analysis.py` to analyze the eval results to compute success rate, timing metric, and overall benchmark performance  `fast_p`. 
 
 ```
-
-You can check out `scripts/greedy_analysis.py` to analyze the eval results.
-We provide some reference baseline times a variety of NVIDIA GPUs across generations in `results/timing`.
+python3 scripts/benchmark_eval_analysis.py run_name=test_hf_level_1 level=1 hardware=L40S_matx3 baseline=baseline_time_torch
+```
+If you are using a different hardware, you can generate the baseline time with `scripts/generate_baseline_time.py` script.
+We provide some reference baseline times a variety of NVIDIA GPUs across generations in `results/timing`, but we recommend you to generate your own baseline time for more accurate results (cluster power, software version, all affects timing result). See `results/timing/README.md` for more details.
 
 ## 🛣️ Upcoming Roadmap
 - [ ] Triton Variant (Ongoing)

--- a/scripts/greedy_analysis.py
+++ b/scripts/greedy_analysis.py
@@ -1,5 +1,19 @@
 import json, os
 from tabulate import tabulate
+import pydra
+from pydra import REQUIRED, Config
+
+class EvalConfig(Config):
+    def __init__(self):
+
+        self.run_name = REQUIRED # name of the run to evaluate
+        self.hardware = REQUIRED # hardware to evaluate
+        self.baseline = REQUIRED # baseline to compare against
+        self.level = REQUIRED # level to evaluate
+
+
+    def __repr__(self):
+        return f"EvalConfig({self.to_dict()})"
 
 def patch(eval_results, dataset):
     """
@@ -95,9 +109,10 @@ def analyze_greedy_eval(run_name, hardware, baseline, level):
     print("\nFast_p Results:")
     print(tabulate(results, headers=["Speedup Threshold (p)", "Fast_p Score"], tablefmt="grid"))
 
-run_name = "trial_greedy_deepseek_r1_level1_A100_modal_v0" # Replace this with your run name
-level = 1 # Replace this with your level
-hardware = "A100_modal" # Replace this with your hardware
-baseline = "baseline_time_torch" # Replace this with your baseline
 
-analyze_greedy_eval(run_name, hardware, baseline, level)
+@pydra.main(base=EvalConfig)
+def main(config: EvalConfig):
+    analyze_greedy_eval(config.run_name, config.hardware, config.baseline, config.level)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/greedy_analysis.py
+++ b/scripts/greedy_analysis.py
@@ -1,45 +1,103 @@
 import json, os
+from tabulate import tabulate
 
-"""
-Analyze the greedy eval results for a run of a particular level
-"""
-from src.dataset import construct_kernelbench_dataset
-run_name = "test_hf_level_1"  # Replace this with your run name
-level = 1 # change if needed
+def patch(eval_results, dataset):
+    """
+    Patch the eval results with the dataset
+    """
+    for pid in range(1, len(dataset) + 1):
+        if str(pid) not in eval_results:
+            eval_results[str(pid)] = {
+                "sample_id": 0, 
+                "compiled": False, 
+                "correctness": False, 
+                "metadata": {},
+                "runtime": -1.0, 
+                "runtime_stats": {}
+            }
+    return eval_results
 
-dataset = construct_kernelbench_dataset(level)
+def analyze_greedy_eval(run_name, hardware, baseline, level):
+    """
+    Analyze the greedy eval results for a run of a particular level
+    """
+    from src.dataset import construct_kernelbench_dataset
+
+    dataset = construct_kernelbench_dataset(level)
+
+    # load json
+    eval_file_path = f'runs/{run_name}/eval_results.json'
+    assert os.path.exists(eval_file_path), f"Eval file does not exist at {eval_file_path}"
+
+    baseline_file_path = f'results/timing/{hardware}/{baseline}.json'
+    assert os.path.exists(baseline_file_path), f"Baseline file does not exist at {baseline_file_path}"
+
+    with open(eval_file_path, 'r') as f:
+        eval_results = json.load(f)
+
+    with open(baseline_file_path, 'r') as f:
+        baseline_results = json.load(f)
+
+    # Initialize counters
+    total_count = len(dataset)
+    total_eval = len(eval_results)
+    compiled_count = 0
+    correct_count = 0
+
+    # Patch the eval results
+    eval_results = patch(eval_results, dataset)
+
+    # Count results
+    for entry in eval_results.values():
+        if entry["compiled"] == True:
+            compiled_count += 1
+        if entry["correctness"] == True:
+            correct_count += 1
+
+    # Print results
+    print("-" * 128)
+    print(f"Eval Summary for {run_name}")
+    print("-" * 128)
+    print(f"Total test cases with Eval Results: {total_eval} out of {total_count}")
+    print(f"Successfully compiled: {compiled_count}")
+    print(f"Functionally correct: {correct_count}")
+
+    print(f"\nSuccess rates:")
+    print(f"Compilation rate: {compiled_count/total_count*100:.1f}%")
+    print(f"Correctness rate: {correct_count/total_count*100:.1f}%") 
 
 
-# load json
-eval_file_path = f'runs/{run_name}/eval_results.json'
-assert os.path.exists(eval_file_path), f"Eval file does not exist at {eval_file_path}"
+    # Calculate speedup metrics
+    from src.score import geometric_mean_speed_ratio_correct_only, geometric_mean_speed_ratio_correct_and_faster_only, fastp
+    import numpy as np
+
+    # Extract the speedup values
+    is_correct = np.array([entry["correctness"] for entry in eval_results.values()])
+    baseline_speed = np.array([entry["mean"] for entry in baseline_results[f'level{level}'].values()])
+    actual_speed = np.array([entry["runtime"] for entry in eval_results.values()])
+    n = len(is_correct)
+
+    assert len(baseline_speed) == n, "Baseline speedup values do not match the number of eval results"
+    assert len(actual_speed) == n, "Actual speedup values do not match the number of eval results"
+
+    # Calculate the metrics
+    gmsr_correct = geometric_mean_speed_ratio_correct_only(is_correct, baseline_speed, actual_speed, n)
+
+    p_values = [0.0, 0.5, 1.0, 1.5, 2.0]
+    results = [[p, fastp(is_correct, baseline_speed, actual_speed, n, p)] for p in p_values]
 
 
-with open(eval_file_path, 'r') as f:
-    eval_results = json.load(f)
+    # Print the results
+    print("\nSpeedup Metrics:")
+    print(f"Geometric mean of speedup for correct samples: {gmsr_correct:.4f}")
 
+    # Print table
+    print("\nFastp Results:")
+    print(tabulate(results, headers=["P Value", "Fastp Score"], tablefmt="grid"))
 
-# Initialize counters
-total_count = len(dataset)
-total_eval = len(eval_results)
-compiled_count = 0
-correct_count = 0
+run_name = "trial_greedy_deepseek_r1_level1_A100_modal_v0" # Replace this with your run name
+level = 1 # Replace this with your level
+hardware = "A100_modal" # Replace this with your hardware
+baseline = "baseline_time_torch" # Replace this with your baseline
 
-# Count results
-for entry in eval_results.values():
-    if entry["compiled"] == True:
-        compiled_count += 1
-    if entry["correctness"] == True:
-        correct_count += 1
-
-# Print results
-print("-" * 128)
-print(f"Eval Summary for {run_name}")
-print("-" * 128)
-print(f"Total test cases with Eval Results: {total_eval} out of {total_count}")
-print(f"Successfully compiled: {compiled_count}")
-print(f"Functionally correct: {correct_count}")
-
-print(f"\nSuccess rates:")
-print(f"Compilation rate: {compiled_count/total_count*100:.1f}%")
-print(f"Correctness rate: {correct_count/total_count*100:.1f}%") 
+analyze_greedy_eval(run_name, hardware, baseline, level)

--- a/scripts/greedy_analysis.py
+++ b/scripts/greedy_analysis.py
@@ -83,7 +83,7 @@ def analyze_greedy_eval(run_name, hardware, baseline, level):
     # Calculate the metrics
     gmsr_correct = geometric_mean_speed_ratio_correct_only(is_correct, baseline_speed, actual_speed, n)
 
-    p_values = [0.0, 0.5, 1.0, 1.5, 2.0]
+    p_values = [0.0, 0.5, 0.8, 1.0, 1.5, 2.0]
     results = [[p, fastp(is_correct, baseline_speed, actual_speed, n, p)] for p in p_values]
 
 
@@ -92,8 +92,8 @@ def analyze_greedy_eval(run_name, hardware, baseline, level):
     print(f"Geometric mean of speedup for correct samples: {gmsr_correct:.4f}")
 
     # Print table
-    print("\nFastp Results:")
-    print(tabulate(results, headers=["P Value", "Fastp Score"], tablefmt="grid"))
+    print("\nFast_p Results:")
+    print(tabulate(results, headers=["Speedup Threshold (p)", "Fast_p Score"], tablefmt="grid"))
 
 run_name = "trial_greedy_deepseek_r1_level1_A100_modal_v0" # Replace this with your run name
 level = 1 # Replace this with your level

--- a/src/compile.py
+++ b/src/compile.py
@@ -1,0 +1,161 @@
+from dataclasses import dataclass
+import random
+import time
+
+from tqdm import tqdm
+
+import shutil
+from src.eval import build_compile_cache, fetch_kernel_from_database, KernelExecResult
+from src import utils as utils
+import torch
+import os
+import multiprocessing as mp
+
+@dataclass
+class WorkArgs:
+    problem_id: int
+    sample_id: int
+    device: torch.device
+
+def compile_single_sample(work_args: WorkArgs, config: dict) -> tuple[bool, str]:
+
+    problem_id = work_args.problem_id 
+    sample_id = work_args.sample_id
+    verbose = config["verbose"]
+    
+    utils.set_gpu_arch(config["gpu_arch"])
+
+    build_dir = os.path.join(config["kernel_eval_build_dir"], config["run_name"], str(problem_id), str(sample_id))
+
+    run_dir = os.path.join(config["runs_dir"], config["run_name"])
+    kernel_src_path = os.path.join(run_dir, f"level_{config['level']}_problem_{problem_id}_sample_{sample_id}_kernel.py")
+
+    if not os.path.exists(kernel_src_path):
+        print(f"[ERROR] Kernel source file not found for Problem ID: {problem_id}, Sample ID: {sample_id}")
+        return False, "Kernel source file not found"
+
+    with open(kernel_src_path, "r") as f:
+        kernel_src = f.read()
+
+    try:
+        compiled_and_cached, stdout_content, error_msg = build_compile_cache(custom_model_src=kernel_src,
+                                                       verbose=verbose, 
+                                                       build_dir=build_dir)
+
+        return compiled_and_cached, stdout_content, error_msg
+    except Exception as e:
+        print(f"[WARNING] Last level catch on {sample_id}: Some issue while compiling and attempting to cache for kernel: {e} ")
+        return None, str(e), str(e)
+    
+def remove_cache_dir(config, problem_id, sample_id):
+    """
+    Remove the cached folder for sample compilation so it can start a clean build next time
+    useful for time out, failed build, etc.
+    """
+    cache_dir = os.path.join(config['kernel_eval_build_dir'], config["run_name"], f"{problem_id}", f"{sample_id}")
+    print(f"cache_dir to remove: {cache_dir}")
+    if os.path.exists(cache_dir):
+        try:
+            # Add error handling and retry with force
+            shutil.rmtree(cache_dir, ignore_errors=True)
+            print(f"\n[INFO] Removed cached folder for Problem ID: {problem_id}, Sample ID: {sample_id}")
+        except Exception as e:
+            print(f"\n[WARNING] Failed to remove cache directory {cache_dir}: {str(e)}")
+
+def batch_compile(total_work: list[tuple[int, int]], config: dict):
+    """
+    Batch compile cache across CPUs
+    """
+    if mp.get_start_method(allow_none=True) is None:
+        mp.set_start_method('spawn')
+
+    try:
+        with mp.Pool(config["num_cpus"]) as pool:
+            # Create work args for each task
+            work_args = [
+                (WorkArgs(problem_id=p_id, sample_id=s_idx, device=None), config)
+                for p_id, s_idx in total_work
+            ]
+
+
+            # Launch all tasks in parallel and track start times
+            async_results = []
+            start_times = {}
+            for i, work_arg in enumerate(work_args):
+                # this is type AsyncResult
+                async_result = pool.apply_async(compile_single_sample, args=work_arg)
+                async_results.append(async_result)
+                start_times[id(async_result)] = time.time()
+            
+            results = []
+            pending_tasks = list(enumerate(async_results))
+            
+            with tqdm(total=len(work_args), desc="Compile & Cache Progress") as pbar:
+                while pending_tasks:
+                    remaining_tasks = []
+                    for i, async_result in pending_tasks:
+                        try:
+                            problem_id, sample_id = total_work[i] # curr code of interest
+                            if async_result.ready():
+                                try:
+                                    compiled, stdout_content, error_msg = async_result.get(timeout=1)  # Short timeout for completed tasks
+                                    
+                                    print(f"[Status] Compilation {compiled} for problem {problem_id} sample {sample_id}")
+                                    results.append((i, compiled))
+
+                                    if not compiled:
+                                        # Remove the cached folder for this timed out sample so it can start a clean build next time                                        problem_id, sample_id = total_work[i]
+                                        remove_cache_dir(config, problem_id, sample_id)
+                                        
+                                    pbar.update(1)
+                                except Exception as e:
+                                    problem_id, sample_id = total_work[i]
+                                    with open("error_log.txt", "a") as f:
+                                        f.write(f"\n[ERROR] Task failed for Problem ID: {problem_id}, Sample ID: {sample_id}: {str(e)}")
+                                    print(f"\n[ERROR] Task failed for Problem ID: {problem_id}, Sample ID: {sample_id}: {str(e)}")
+                                    remove_cache_dir(config, problem_id, sample_id)
+                                    results.append((i, None))
+                                    pbar.update(1)
+                            else:
+                                # Check if the task has exceeded timeout
+                                if time.time() - start_times[id(async_result)] > config["timeout"]:
+                                    problem_id, sample_id = total_work[i]
+                                    print(f"\n[TIME OUT] Task timed out for Problem ID: {problem_id}, Sample ID: {sample_id}")
+                                    
+                                    problem_id, sample_id = total_work[i]
+                                    remove_cache_dir(config, problem_id, sample_id)
+
+                                    # if we were to retry!
+                                    # Start a new task for the same work
+                                    print(f"Retrying for Problem ID: {problem_id}, Sample ID: {sample_id}")
+                                    new_async_result = pool.apply_async(compile_single_sample, args=work_args[i])
+                                    start_times[id(new_async_result)] = time.time()
+                                    remaining_tasks.append((i, new_async_result))
+                                else:
+                                    # keep going 
+                                    remaining_tasks.append((i, async_result))
+
+                        except Exception as e:
+                            problem_id, sample_id = total_work[i]
+                            print(f"\n[ERROR] Unexpected error for Problem ID: {problem_id}, Sample ID: {sample_id}: {str(e)}")
+                            
+                            remove_cache_dir(config, problem_id, sample_id)
+                            
+                            results.append((i, None))
+                            
+                            pbar.update(1)
+                    
+                    pending_tasks = remaining_tasks
+                    time.sleep(0.1)  # Prevent busy waiting
+            
+            # Sort results back to original order
+            sorted_results = [r for _, r in sorted(results, key=lambda x: x[0])]
+            return sorted_results
+
+    except KeyboardInterrupt:
+        print("\nKeyboard interrupt detected. Terminating workers...")
+        pool.terminate()
+        raise
+    finally:
+        if 'pool' in locals():
+            pool.close()

--- a/src/score.py
+++ b/src/score.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+def geometric_mean_speed_ratio_correct_only(is_correct: np.ndarray, baseline_speed: np.ndarray, actual_speed: np.ndarray, n: int) -> float:
+    """
+    Geometric mean of the speed ratio for correct samples
+    """
+    filtered_baseline_speed = np.array([x for i, x in enumerate(baseline_speed) if is_correct[i]])
+    filtered_actual_speed = np.array([x for i, x in enumerate(actual_speed) if is_correct[i]])
+    speed_up = filtered_baseline_speed / filtered_actual_speed
+    prod = np.prod(speed_up)
+    n_correct = np.sum(is_correct) # Count number of correct samples
+
+    return prod ** (1 / n_correct) if n_correct > 0 else 0
+
+def geometric_mean_speed_ratio_correct_and_faster_only(is_correct: np.ndarray, baseline_speed: np.ndarray, actual_speed: np.ndarray, n: int) -> float:
+    """
+    Geometric mean of the speed ratio for correct samples that have speedup > 1
+    """
+    filtered_baseline_speed = np.array([x for i, x in enumerate(baseline_speed) if is_correct[i]])
+    filtered_actual_speed = np.array([x for i, x in enumerate(actual_speed) if is_correct[i]])
+    speed_up = filtered_baseline_speed / filtered_actual_speed
+    speed_up = np.array([x for x in speed_up if x > 1])
+    prod = np.prod(speed_up)
+    n_correct_and_faster = len(speed_up)
+
+    return prod ** (1 / n_correct_and_faster) if n_correct_and_faster > 0 else 0
+
+def fastp_range(is_correct: np.ndarray, baseline_speed: np.ndarray, actual_speed: np.ndarray, n: int, p_range: list) -> float:
+    fast_p_scores = dict()
+    for p in p_range:
+        fast_p_scores[p] = float(fastp(is_correct, baseline_speed, actual_speed, n, p))
+    return fast_p_scores
+
+def fastp(is_correct: np.ndarray, baseline_speed: np.ndarray, actual_speed: np.ndarray, n: int, p: float) -> float:
+    """
+    Rate of samples within a threshold p
+    """
+    filtered_baseline_speed = np.array([x for i, x in enumerate(baseline_speed) if is_correct[i]])
+    filtered_actual_speed = np.array([x for i, x in enumerate(actual_speed) if is_correct[i]])
+    speed_up = filtered_baseline_speed / filtered_actual_speed
+    fast_p_score = np.sum(speed_up > p)
+    return fast_p_score / n if n > 0 else 0

--- a/src/score.py
+++ b/src/score.py
@@ -25,12 +25,6 @@ def geometric_mean_speed_ratio_correct_and_faster_only(is_correct: np.ndarray, b
 
     return prod ** (1 / n_correct_and_faster) if n_correct_and_faster > 0 else 0
 
-def fastp_range(is_correct: np.ndarray, baseline_speed: np.ndarray, actual_speed: np.ndarray, n: int, p_range: list) -> float:
-    fast_p_scores = dict()
-    for p in p_range:
-        fast_p_scores[p] = float(fastp(is_correct, baseline_speed, actual_speed, n, p))
-    return fast_p_scores
-
 def fastp(is_correct: np.ndarray, baseline_speed: np.ndarray, actual_speed: np.ndarray, n: int, p: float) -> float:
     """
     Rate of samples within a threshold p

--- a/src/unit_tests/test_score.py
+++ b/src/unit_tests/test_score.py
@@ -1,0 +1,123 @@
+import pytest
+from src.score import *
+import math
+
+'''
+Usage:
+pytest test_score.py
+'''
+
+abs_tol = 0.0000001
+
+def test_geometric_mean_speed_ratio_correct_only():
+
+    is_correct = [1,0,1,1,0]
+    baseline_speed = [0.1, 0.15, 0.2, 0.05, 0.3]
+    actual_speed = [0.2, 0.15, 0.3, 0.01, 0.2]
+    n = 5
+
+    '''
+    Geometric mean of the speed ratio for correct samples
+    '''
+    assert math.isclose(geometric_mean_speed_ratio_correct_only(is_correct, baseline_speed, actual_speed, n), 1.185631101, abs_tol=abs_tol)
+
+    is_correct = [1,1,1,1,0]
+    baseline_speed = [0.24, 0.31, 100.0, 0.0001, 0.3]
+    actual_speed = [0.3, 0.3, 200.0, 0.0001, 0.3]
+    n = 5
+
+    assert math.isclose(geometric_mean_speed_ratio_correct_only(is_correct, baseline_speed, actual_speed, n), 0.801816719, abs_tol=abs_tol)
+
+    is_correct = [0,0,0,0,0]
+    baseline_speed = [0.1, 0.15, 0.2, 0.05, 0.3]
+    actual_speed = [0.2, 0.15, 0.3, 0.01, 0.2]
+    n = 5
+
+    assert math.isclose(geometric_mean_speed_ratio_correct_only(is_correct, baseline_speed, actual_speed, n), 0, abs_tol=abs_tol)
+
+
+def test_geometric_mean_speed_ratio_correct_and_faster_only():
+
+    is_correct = [1,0,1,1,0]
+    baseline_speed = [0.1, 0.15, 0.2, 0.05, 0.3]
+    actual_speed = [0.2, 0.15, 0.3, 0.01, 0.2]
+    n = 5
+
+    '''
+    Geometric mean of the speed ratio for correct samples that have speedup > 1
+    '''
+
+    assert math.isclose(geometric_mean_speed_ratio_correct_and_faster_only(is_correct, baseline_speed, actual_speed, n), 5, abs_tol=abs_tol)
+
+    is_correct = [1,1,1,1,0]
+    baseline_speed = [0.24, 0.31, 100.0, 0.0001, 0.3]
+    actual_speed = [0.3, 0.3, 200.0, 0.0001, 0.3]
+    n = 5
+
+    assert math.isclose(geometric_mean_speed_ratio_correct_and_faster_only(is_correct, baseline_speed, actual_speed, n), 1.033333333, abs_tol=abs_tol)
+
+    is_correct = [0,0,0,0,0]
+    baseline_speed = [0.1, 0.15, 0.2, 0.05, 0.3]
+    actual_speed = [0.2, 0.15, 0.3, 0.01, 0.2]
+    n = 5
+
+    assert math.isclose(geometric_mean_speed_ratio_correct_and_faster_only(is_correct, baseline_speed, actual_speed, n), 0, abs_tol=abs_tol)
+
+def test_fastp():
+
+    '''
+    Rate of samples within a threshold p (1.0)
+    '''
+
+    is_correct = [1,0,1,1,0]
+    baseline_speed = [0.1, 0.15, 0.2, 0.05, 0.3]
+    actual_speed = [0.2, 0.15, 0.3, 0.01, 0.2]
+    n = 5
+    p = 1.0
+
+    assert math.isclose(fastp(is_correct, baseline_speed, actual_speed, n, p), 0.2, abs_tol=abs_tol)
+
+    is_correct = [1,1,1,1,0]
+    baseline_speed = [0.24, 0.31, 100.0, 0.0001, 0.3]
+    actual_speed = [0.3, 0.3, 200.0, 0.0001, 0.3]
+    n = 5
+    p = 1.0
+
+    assert math.isclose(fastp(is_correct, baseline_speed, actual_speed, n, p), 0.2, abs_tol=abs_tol)
+
+    is_correct = [0,0,0,0,0]
+    baseline_speed = [0.1, 0.15, 0.2, 0.05, 0.3]
+    actual_speed = [0.2, 0.15, 0.3, 0.01, 0.2]
+    n = 5
+    p = 1.0
+
+    assert math.isclose(fastp(is_correct, baseline_speed, actual_speed, n, p), 0, abs_tol=abs_tol)
+
+    '''
+    Rate of samples within a threshold p (0.5)
+    '''
+
+    is_correct = [1,0,1,1,0]
+    baseline_speed = [0.1, 0.15, 0.2, 0.05, 0.3]
+    actual_speed = [0.2, 0.15, 0.3, 0.01, 0.2]
+    n = 5
+    p = 0.5
+
+    assert math.isclose(fastp(is_correct, baseline_speed, actual_speed, n, p), 0.4, abs_tol=abs_tol)
+
+    is_correct = [1,1,1,1,0]
+    baseline_speed = [0.24, 0.31, 100.0, 0.0001, 0.3]
+    actual_speed = [0.3, 0.3, 200.0, 0.0001, 0.3]
+    n = 5
+    p = 0.5
+
+    assert math.isclose(fastp(is_correct, baseline_speed, actual_speed, n, p), 0.6, abs_tol=abs_tol)
+
+    is_correct = [0,0,0,0,0]
+    baseline_speed = [0.1, 0.15, 0.2, 0.05, 0.3]
+    actual_speed = [0.2, 0.15, 0.3, 0.01, 0.2]
+    n = 5
+    p = 0.5
+
+    assert math.isclose(fastp(is_correct, baseline_speed, actual_speed, n, p), 0, abs_tol=abs_tol)
+


### PR DESCRIPTION
In the KernelBench [arxiv](https://arxiv.org/abs/2502.10517) we introduce a metric `fast_p` to measure both correctness and speedup across whole benchmark level.

`fast_p` is defined as the percentage of problems where model generated a correct and **p**-times faster kernel than baseline (PyTorch eager or `torch.compile`)

We add the logic to compute `fast_p` as well as geometric mean (which we have and others have reported on KernelBench as well). The problem with geometric mean is that if some problem has very high speedup, the overall speedup can get skewed. Hence, we came up with `fast_p` metric as a binary filtering metric.

In this PR 
* Add code for computing speedup and benchmark score, add unit tests for those
* Add fast_p report in `greedy_analysis`. You can reproduce the paper in our results with that. 
* We added CPU cache building in the public eval code. This is an optional feature, where you can parallel (over num CPU workers) to build kernel binaries, to speedup actual eval stage time if you have a cache hit of the compiled binary. Since only running kernel needs GPU, it is best to compile them on CPU beforehand and parallelize the compilation process. We only save the correctly compiled ones to cache on disk, as we want the eval script to catch the error message for the incorrect ones.

