### PR TITLE
Add cleaned Level 1 tasks from kernelbench-revamp

### DIFF
--- a/KernelBench/level1/100_HingeLoss.py
+++ b/KernelBench/level1/100_HingeLoss.py
@@ -19,7 +19,7 @@ input_shape = (1,)
 dim = 1
 
 def get_inputs():
-    return [torch.randn(batch_size, *input_shape), torch.randint(0, 2, (batch_size, 1)).float() * 2 - 1]
+    return [torch.randn(batch_size, *input_shape), torch.randint(0, 2, (batch_size,)).float() * 2 - 1]
 
 def get_init_inputs():
     return []

--- a/KernelBench/level1/38_L1Norm_.py
+++ b/KernelBench/level1/38_L1Norm_.py
@@ -21,7 +21,7 @@ class Model(nn.Module):
         Returns:
             torch.Tensor: Output tensor with L1 normalization applied, same shape as input.
         """
-        return x / torch.sum(torch.abs(x), dim=1, keepdim=True)
+        return x / torch.mean(torch.abs(x), dim=1, keepdim=True)
 
 batch_size = 16
 dim = 16384

--- a/KernelBench/level1/50_conv_standard_2D__square_input__square_kernel.py
+++ b/KernelBench/level1/50_conv_standard_2D__square_input__square_kernel.py
@@ -1,0 +1,22 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+class Model(nn.Module):
+    def __init__(self, num_classes=1000):
+        super(Model, self).__init__()
+        self.conv1 = nn.Conv2d(in_channels=3, out_channels=96, kernel_size=11, stride=4, padding=2)
+    
+    def forward(self, x):
+        x = self.conv1(x)
+        return x
+
+# Test code
+batch_size = 100
+num_classes = 1000
+
+def get_inputs():
+    return [torch.randn(batch_size, 3, 224, 224)]
+
+def get_init_inputs():
+    return [num_classes]

--- a/KernelBench/level1/94_MSELoss.py
+++ b/KernelBench/level1/94_MSELoss.py
@@ -19,7 +19,8 @@ input_shape = (4096, )
 dim = 1
 
 def get_inputs():
-    return [torch.randn(batch_size, *input_shape), torch.randn(batch_size, *input_shape)]
+    scale = torch.randn(())
+    return [torch.randn(batch_size, *input_shape)*scale, torch.randn(batch_size, *input_shape)]
 
 def get_init_inputs():
     return []

--- a/KernelBench/level1/96_HuberLoss.py
+++ b/KernelBench/level1/96_HuberLoss.py
@@ -19,7 +19,8 @@ input_shape = (4096, )
 dim = 1
 
 def get_inputs():
-    return [torch.randn(batch_size, *input_shape), torch.randn(batch_size, *input_shape)]
+    scale = torch.randn(())
+    return [torch.randn(batch_size, *input_shape)*scale, torch.randn(batch_size, *input_shape)]
 
 def get_init_inputs():
     return []

--- a/KernelBench/level1/97_ScaledDotProductAttention.py
+++ b/KernelBench/level1/97_ScaledDotProductAttention.py
@@ -1,0 +1,24 @@
+import torch
+import torch.nn as nn
+
+class Model(nn.Module):
+    def __init__(self):
+        super(Model, self).__init__()
+
+    def forward(self, Q: torch.Tensor, K: torch.Tensor, V: torch.Tensor) -> torch.Tensor:
+        out = torch.nn.functional.scaled_dot_product_attention(Q, K, V)
+        return out
+
+batch_size = 2
+num_heads = 32
+sequence_length = 256
+embedding_dimension = 1024
+
+def get_inputs():
+    Q = torch.randn(batch_size, num_heads, sequence_length, embedding_dimension, device='cuda', dtype=torch.float16)
+    K = torch.randn(batch_size, num_heads, sequence_length, embedding_dimension, device='cuda', dtype=torch.float16)
+    V = torch.randn(batch_size, num_heads, sequence_length, embedding_dimension, device='cuda', dtype=torch.float16)
+    return [Q, K, V]
+
+def get_init_inputs():
+    return []

--- a/KernelBench/level1/98_KLDivLoss.py
+++ b/KernelBench/level1/98_KLDivLoss.py
@@ -19,7 +19,8 @@ input_shape = (4096, )
 dim = 1
 
 def get_inputs():
-    return [torch.randn(batch_size, *input_shape).softmax(dim=-1), torch.randn(batch_size, *input_shape).softmax(dim=-1)]
+    scale = torch.randn(())
+    return [(torch.randn(batch_size, *input_shape)*scale).softmax(dim=-1), torch.randn(batch_size, *input_shape).softmax(dim=-1)]
 
 def get_init_inputs():
     return []

--- a/KernelBench/level1/99_TripletMarginLoss.py
+++ b/KernelBench/level1/99_TripletMarginLoss.py
@@ -20,7 +20,8 @@ input_shape = (4096, )
 dim = 1
 
 def get_inputs():
-    return [torch.randn(batch_size, *input_shape), torch.randn(batch_size, *input_shape), torch.randn(batch_size, *input_shape)]
+    scale = torch.randn(())
+    return [torch.randn(batch_size, *input_shape)*scale, torch.randn(batch_size, *input_shape), torch.randn(batch_size, *input_shape)]
 
 def get_init_inputs():
     return [1.0]  # Default margin


### PR DESCRIPTION
Finalized level 1 tasks. 

Modified:
100_HingeLoss.py 
38_L1Norm_.py 
94_MSELoss.py 
96_HuberLoss.py 
98_KLDivLoss.py
99_TripletMarginLoss.py 

Replaced:
50_Product_reduction_over_a_dimension.py
97_CosineSimilarityLoss.py