### PR TITLE
fix metric calculation caused by mismatched pair comparisons

### DIFF
--- a/scripts/benchmark_eval_analysis.py
+++ b/scripts/benchmark_eval_analysis.py
@@ -47,6 +47,7 @@ def patch(eval_results, dataset):
                 "runtime": -1.0, 
                 "runtime_stats": {}
             }
+        eval_results = dict(sorted(eval_results.items(), key=lambda x: int(x[0])))
     return eval_results
 
 def analyze_greedy_eval(run_name, hardware, baseline, level):


### PR DESCRIPTION
The evaluation results must be saved in the order of their keys (`problem_id`). Otherwise, when some eval results are missing, the speedup computed with `geometric_mean_speed_ratio_correct_only` would use mismatched pairs and produce incorrect results.