### PR TITLE
Fix shape for exclusive cumulative sum

### DIFF
--- a/KernelBench/level1/92_cumsum_exclusive.py
+++ b/KernelBench/level1/92_cumsum_exclusive.py
@@ -14,7 +14,7 @@ class Model(nn.Module):
         self.dim = dim
 
     def forward(self, x):
-        exclusive_cumsum = torch.cat((torch.zeros_like(x.select(self.dim, 0).unsqueeze(self.dim)), x), dim=self.dim)[:-1]
+        exclusive_cumsum = torch.cat((torch.zeros_like(x.select(self.dim, 0).unsqueeze(self.dim)), x), dim=self.dim).narrow(self.dim, 0, x.size(dim))
         return torch.cumsum(exclusive_cumsum, dim=self.dim)
 
 batch_size = 32768


### PR DESCRIPTION
The current implementation of exclusive cumsum zero-pads the input at dim 1 and incorrectly slice the input along dim 0. For input with shape [32768, 32768], the output will be [32767, 32769], which is wrong semantically. This PR fixed this problem using narrow api to slice the tensor at the correct dim.