### PR TITLE
Adding modal support to run_and_check.py 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To evaluate model-generated kernels, we need to check if they:
 
 Check out `src/eval.py` for details on how we implement correctness check and timing. 
 
-We provide a convenient script `scripts/run_and_check.py` to evaluate one single sample source code against a reference source code, check correctness and compute speedup. You can use this to evaluate a model-generated kernel. 
+We provide a convenient script `scripts/run_and_check.py` to evaluate one single sample source code against a reference source code, check correctness and compute speedup. You can use this to evaluate a kernel either locally or remotely by setting `eval_mode=local` or `eval_mode=modal`.
 
 #### Overall Benchmark Metric
 

--- a/scripts/eval_from_generations.py
+++ b/scripts/eval_from_generations.py
@@ -68,17 +68,13 @@ image = (
                 "clang"
                 )
     .pip_install(
-        "anthropic",
         "numpy",
-        "openai",
         "packaging",
         "pydra_config",
         "torch==2.5.0",
         "tqdm",
         "datasets",
         "transformers",
-        "google-generativeai",
-        "together",
         "pytest",
         "ninja",
         "utils",

--- a/scripts/generate_baseline_time_modal.py
+++ b/scripts/generate_baseline_time_modal.py
@@ -68,17 +68,14 @@ image = (
                 "clang" # note i skip a step 
                 )
     .pip_install(  # required to build flash-attn
-        "anthropic",
+        # Let's unify these dependencies somewhere
         "numpy",
-        "openai",
         "packaging",
         "pydra_config",
         "torch==2.5.0",
         "tqdm",
         "datasets",
         "transformers",
-        "google-generativeai",
-        "together",
         "pytest",
         "ninja",
         "utils",

--- a/scripts/run_and_check.py
+++ b/scripts/run_and_check.py
@@ -36,17 +36,13 @@ image = (
     modal.Image.from_registry(f"nvidia/cuda:{tag}", add_python="3.10")
     .apt_install("git", "gcc-10", "g++-10", "clang")
     .pip_install(
-        "anthropic",
         "numpy",
-        "openai",
         "packaging",
         "pydra_config",
         "torch==2.5.0",
         "tqdm",
         "datasets",
         "transformers",
-        "google-generativeai",
-        "together",
         "pytest",
         "ninja",
         "utils",


### PR DESCRIPTION
Added modal support to run and check. Can now run_and_check.py with Modal GPUs using eval_mode=modal. Also an effort to debug a CUDA OOM error due to large tensor sizes on the L40S. 