### PR TITLE
fixing modal bug

### DIFF
--- a/scripts/eval_from_generations.py
+++ b/scripts/eval_from_generations.py
@@ -223,6 +223,7 @@ class ModalEvaluator:
         except (torch.cuda.CudaError, torch.AcceleratorError) as e:
             # GPU error detected - retire this container to prevent contamination
             gpu_corrupted = True
+            # TODO: Replace with more stable API in the future, thanks modal team for temp workaround.
             modal.experimental.stop_fetching_inputs()
             result = KernelExecResult(
                 compiled=False,
@@ -487,6 +488,7 @@ def batch_eval_modal(
                 
                 # Spawn all tasks in parallel
                 # Modal assigns these to available containers
+                # sometimes GPU mem state is corrupted so we will drain this container and find a new one with clean mem state.
                 # GPU corruption is handled via stop_fetching_inputs() in evaluate_single_sample_modal
                 futures = []
                 for item in work_items:


### PR DESCRIPTION
There was a bug in eval_from_generations that was: 

When a bad kernel (e.g. illegal memory access) corrupts the GPU memory state, several subsequent kernels (that would be in that same Modal container) would also be evaluated on that GPU, also rendering them incorrect automatically, regardless if they were right or not. The fix is to launch a new container when the GPU is left in a "bad" state. 