### PR TITLE
 Fix Issue #97: Use Heavy-Tailed Distribution for MSELoss to Prevent Partial Computation from Passing Verification

### DIFF
--- a/KernelBench/level1/94_MSELoss.py
+++ b/KernelBench/level1/94_MSELoss.py
@@ -1,5 +1,6 @@
 import torch
 import torch.nn as nn
+from torch.distributions import Pareto
 
 class Model(nn.Module):
     """
@@ -19,8 +20,9 @@ input_shape = (32768,)
 dim = 1
 
 def get_inputs():
-    scale = torch.rand(())
-    return [torch.rand(batch_size, *input_shape)*scale, torch.rand(batch_size, *input_shape)]
+    predictions = Pareto(0.01, 1.5).sample((batch_size, *input_shape))
+    targets = Pareto(0.01, 1.5).sample((batch_size, *input_shape))
+    return [predictions, targets]
 
 def get_init_inputs():
     return []


### PR DESCRIPTION
#  Fix Issue #97: Use Heavy-Tailed Distribution for MSELoss to Prevent Partial Computation from Passing Verification

## Summary

Replace uniform distribution with Pareto distribution in `level1/94_MSELoss.py` input generation to detect incorrect kernel implementations that only compute partial data.

## Problem

The original implementation uses uniform distribution for test data generation:
```
def get_inputs():
    scale = torch.rand(())
    return [torch.rand(batch_size, *input_shape)*scale, torch.rand(batch_size, *input_shape)]
```

Due to the bounded moments of uniform distribution, by the Law of Large Numbers, MSE converges to the same expected value $(2s^2 - 3s + 2)/6$ regardless of sample size. This allows faulty kernel implementations (e.g., computing only part of the data) to pass accuracy verification.


## Solution

Adopt Pareto distribution `Pareto(scale=0.01, alpha=1.5)` (or other heavy-tailed distributions with divergent second moments):
- Bounded first moment (α=1.5 > 1): Ensures numerical stability
- Divergent second moment (α=1.5 ≤ 2): MSE expectation grows with sample size

This ensures implementations with different computation volumes produce significantly different outputs, correctly detecting faulty kernel implementations.

## Changed Files

- `KernelBench/level1/94_MSELoss.py`
