### PR TITLE
correct the A100 40GB memory bandwidth entry in gpu_specs

### DIFF
--- a/src/prompts/hardware/gpu_specs.py
+++ b/src/prompts/hardware/gpu_specs.py
@@ -44,7 +44,7 @@ GPU_SPEC_INFO = {
     "A100": {
         "GPU Architecture": "Ampere",
         "GPU Memory": "40GB",
-        "Memory Bandwidth": "1935 GB/s",
+        "Memory Bandwidth": "1555 GB/s",
         "FP64 TFLOPS": "9.7",
         "FP64 Tensor Core TFLOPS": "19.5",
         "FP32 TFLOPS": "19.5",


### PR DESCRIPTION
This pull request corrects an erroneous memory bandwidth value for the A100 40GB GPU within the gpu_specs configuration file. The modification ensures that the stored hardware specifications are accurate, which is vital for any system or prompt relying on this data.