### PR TITLE
Add support to non-fp32 input dtype in `level3/33_VanillaRNN.py` and `level3/35_LSTM.py`

### DIFF
--- a/KernelBench/level3/33_VanillaRNN.py
+++ b/KernelBench/level3/33_VanillaRNN.py
@@ -31,7 +31,7 @@ class Model(nn.Module):
         """
         if initial_hidden is not None:
             self.hidden.copy_(initial_hidden)
-        self.hidden = self.hidden.to(x.device)
+        self.hidden = self.hidden.to(x.device).to(x.dtype)
         combined = torch.cat((x, self.hidden), dim=1)  # Concatenate input and hidden state
         self.hidden = self.tanh(self.i2h(combined))  # Update hidden state
         output = self.h2o(self.hidden)  # Compute output

--- a/KernelBench/level3/35_LSTM.py
+++ b/KernelBench/level3/35_LSTM.py
@@ -31,9 +31,9 @@ class Model(nn.Module):
         batch_size = x.size(0)
 
         if h0 is None:
-            h0 = torch.randn(self.num_layers, batch_size, self.hidden_size, device=x.device)
+            h0 = torch.randn(self.num_layers, batch_size, self.hidden_size, device=x.device, dtype=x.dtype)
         if c0 is None:
-            c0 = torch.randn(self.num_layers, batch_size, self.hidden_size, device=x.device)
+            c0 = torch.randn(self.num_layers, batch_size, self.hidden_size, device=x.device, dtype=x.dtype)
 
         out, _ = self.lstm(x, (h0, c0))  # out: (batch_size, seq_length, hidden_size)
         out = self.fc(out[:, -1, :])     # out: (batch_size, output_size)


### PR DESCRIPTION
This PR fixes a bug in two problems [`level3/33_VanillaRNN.py`](https://github.com/ScalingIntelligence/KernelBench/blob/6b1cea28ddea79af6b295fb9a3e3413f393efe3d/KernelBench/level3/33_VanillaRNN.py#L17) and [`level3/35_LSTM.py`](https://github.com/ScalingIntelligence/KernelBench/blob/6b1cea28ddea79af6b295fb9a3e3413f393efe3d/KernelBench/level3/35_LSTM.py#L34) that `Model` uses hard-coded FP32 tensors.

It is related to #79 and #80. You will find the bug if you try to run the agent on the two problems.

Please consider updating the dataset in HuggingFace too: https://huggingface.co/datasets/ScalingIntelligence/KernelBench

An alternative fix could be moving the random tensors from `Model` to `get_inputs()`.

## How to reproduce the bug

```console
$ python -i KernelBench/level3/33_VanillaRNN.py
```
```python
init_inputs = get_init_inputs()
inputs = get_inputs()
m = Model(*init_inputs)
output = m(*inputs)
m_bf16 = m.to(dtype=torch.bfloat16)
inputs_bf16 = [inp.to(dtype=torch.bfloat16) for inp in inputs]
output_bf16 = m_bf16(*inputs_bf16)
```
```console
RuntimeError: mat1 and mat2 must have the same dtype, but got Float and BFloat16
```


```console
$ python -i KernelBench/level3/35_LSTM.py
```
```python
init_inputs = get_init_inputs()
inputs = get_inputs()
m = Model(*init_inputs)
output = m(*inputs)
m_bf16 = m.to(dtype=torch.bfloat16)
inputs_bf16 = [inp.to(dtype=torch.bfloat16) for inp in inputs]
output_bf16 = m_bf16(*inputs_bf16)
```
```console
RuntimeError: could not create a primitive descriptor for the LSTM forward propagation primitive. Run workload with environment variable ONEDNN_VERBOSE=all to get additional diagnostic information.
```

## 