### PR TITLE
Fix pytorch_wrap regex to catch both nn.X and torch.nn.X

### DIFF
--- a/src/kernelbench/kernel_static_checker.py
+++ b/src/kernelbench/kernel_static_checker.py
@@ -85,14 +85,19 @@ def check_code_bypass(code: str) -> Tuple[bool, str]:
 # Allows: nn.Module, nn.Parameter, nn.ParameterList, nn.ParameterDict, 
 #         nn.ModuleList, nn.ModuleDict, nn.init (needed for model structure)
 # Blocks: nn.Linear, nn.Conv2d, nn.ReLU, etc. (compute layers)
-PYTORCH_DISALLOWED_NN_PATTERN = r'torch\.nn\.(?!(Module|parameter|Parameter|ParameterList|ParameterDict|ModuleList|ModuleDict|init)\b)'
+PYTORCH_DISALLOWED_NN_PATTERN = r'(?<!\w)nn\.(?!(Module|parameter|Parameter|ParameterList|ParameterDict|ModuleList|ModuleDict|init)\b)'
 
 def check_pytorch_wrap(code: str) -> Tuple[bool, str]:
     """
     Check for PyTorch nn module usage (nn.Linear, nn.Conv2d, etc.).
-    
+
     Allows containers (nn.Module, nn.Parameter, nn.init) needed for model structure.
     Blocks compute layers (nn.Linear, nn.Conv2d, nn.ReLU, etc.).
+
+    Matches both ``nn.Linear`` (from ``from torch import nn``) and
+    ``torch.nn.Linear`` (fully qualified).  Uses a negative lookbehind
+    ``(?<!\\w)`` so that unrelated identifiers ending in "nn" are not
+    matched (e.g. ``cnn.layer``).
     """
     code = _strip_comments(code)
     if re.search(PYTORCH_DISALLOWED_NN_PATTERN, code):


### PR DESCRIPTION
## Summary
- The `pytorch_wrap` check used `torch\.nn\.(?!...)` which only matched fully qualified `torch.nn.Linear` style calls
- Generated kernels commonly use `from torch import nn` then `nn.Conv2d`, `nn.Linear` etc., which slipped through
- Changed pattern to `(?<!\w)nn\.(?!...)` which catches both import styles while avoiding false positives on identifiers like `cnn.layer` via the negative lookbehind

## Test plan
- `nn.Linear` → caught (no word char before `nn`)
- `torch.nn.Linear` → caught (`.` before `nn` is not `\w`)
- `cnn.layer` → not caught (`c` before `nn` is `\w`)
- `nn.Module` → not caught (negative lookahead excludes allowed names)