### PR TITLE
Fix pytorch_wrap regex to catch both nn.X and torch.nn.X

### DIFF
--- a/src/kernelbench/kernel_static_checker.py
+++ b/src/kernelbench/kernel_static_checker.py
@@ -85,12 +85,12 @@ def check_code_bypass(code: str) -> Tuple[bool, str]:
 # Allows: nn.Module, nn.Parameter, nn.ParameterList, nn.ParameterDict, 
 #         nn.ModuleList, nn.ModuleDict, nn.init (needed for model structure)
 # Blocks: nn.Linear, nn.Conv2d, nn.ReLU, etc. (compute layers)
-PYTORCH_DISALLOWED_NN_PATTERN = r'torch\.nn\.(?!(Module|parameter|Parameter|ParameterList|ParameterDict|ModuleList|ModuleDict|init)\b)'
+PYTORCH_DISALLOWED_NN_PATTERN = r'(?<!\w)nn\.(?!(Module|parameter|Parameter|ParameterList|ParameterDict|ModuleList|ModuleDict|init)\b)'
 
 def check_pytorch_wrap(code: str) -> Tuple[bool, str]:
     """
     Check for PyTorch nn module usage (nn.Linear, nn.Conv2d, etc.).
-    
+
     Allows containers (nn.Module, nn.Parameter, nn.init) needed for model structure.
     Blocks compute layers (nn.Linear, nn.Conv2d, nn.ReLU, etc.).
     """


### PR DESCRIPTION
The previous pattern `torch\.nn\.(?!...)` only caught stuff like `torch.nn.Linear` but didn't catch kernels with`from torch import nn` and then `nn.Conv2d`, `nn.Linear`, etc. I changed the pattern to `(?<!\w)nn\.(?!...)` which matches both import styles while avoiding false positives on identifiers like `cnn.layer` via the negative lookbehind.