### PR TITLE
Fix dimensions of 97_ScaledDotProductAttention

### DIFF
--- a/KernelBench/level1/97_ScaledDotProductAttention.py
+++ b/KernelBench/level1/97_ScaledDotProductAttention.py
@@ -12,12 +12,12 @@ class Model(nn.Module):
 batch_size = 32
 num_heads = 32
 sequence_length = 512
-embedding_dimension = 1024
+head_dimension = 32
 
 def get_inputs():
-    Q = torch.rand(batch_size, num_heads, sequence_length, embedding_dimension)
-    K = torch.rand(batch_size, num_heads, sequence_length, embedding_dimension)
-    V = torch.rand(batch_size, num_heads, sequence_length, embedding_dimension)
+    Q = torch.rand(batch_size, num_heads, sequence_length, head_dimension)
+    K = torch.rand(batch_size, num_heads, sequence_length, head_dimension)
+    V = torch.rand(batch_size, num_heads, sequence_length, head_dimension)
     return [Q, K, V]
 
 def get_init_inputs():


### PR DESCRIPTION
In the context of `torch.nn.functional.scaled_dot_product_attention`, the input tensors have shape `(batch_size, num_heads, sequence_length, head_dim)`, where `head_dim` is the dimension per attention head.

The total model embedding dimension equals `num_heads × head_dim`, so for a model with embedding dimension of `1024` and `32` heads, the appropriate dimension would be `32`.
