### PR TITLE
fix(modal): harden modal evaluation against timeouts, cuda corruption, and compute waste

### DIFF
--- a/scripts/eval_from_generations.py
+++ b/scripts/eval_from_generations.py
@@ -231,7 +231,7 @@ class ModalEvaluator:
                 backend=backend,
                 precision=get_torch_dtype_from_string(precision),
             )
-        except (torch.cuda.CudaError, torch.AcceleratorError) as e:
+        except (RuntimeError, torch.cuda.CudaError, torch.AcceleratorError) as e:
             # GPU error detected - retire this container to prevent contamination
             gpu_corrupted = True
             # TODO: Replace with more stable API in the future, thanks modal team for temp workaround.
@@ -248,7 +248,15 @@ class ModalEvaluator:
             )
 
         if not gpu_corrupted:
-            torch.cuda.empty_cache()
+            try:
+                torch.cuda.synchronize()
+                torch.cuda.empty_cache()
+            except Exception as sync_err:
+                gpu_corrupted = True
+                modal.experimental.stop_fetching_inputs()
+                result.correctness = False
+                result.runtime = -1.0
+                result.metadata["cuda_sync_error"] = str(sync_err)
 
         return result
 
@@ -482,7 +490,7 @@ def batch_eval_modal(
                 
                 # Override GPU if different from default in decorator
                 # .with_options() overrides the decorator's parameters
-                evaluator_cls = ModalEvaluator.with_options(gpu=config.gpu) if config.gpu != "A10G" else ModalEvaluator
+                evaluator_cls = ModalEvaluator.with_options(gpu=config.gpu, timeout=config.timeout)
                 
                 # Spawn all tasks in parallel
                 # Modal assigns these to available containers
@@ -524,8 +532,25 @@ def batch_eval_modal(
                         results.append((problem_id, sample_id, fail_result))
                     else:
                         try:
-                            result = future.get()
+                            elapsed_time = time.time() - start_time
+                            remaining_time = max(0.0, (config.timeout + 60) - elapsed_time)
+                            result = future.get(timeout=remaining_time)
                             results.append((problem_id, sample_id, result))
+                        except (TimeoutError, modal.exception.TimeoutError) as e:
+                            try:
+                                future.cancel(terminate_containers=True)
+                            except Exception as cancel_err:
+                                print(f"[WARNING] Could not cancel Modal container: {cancel_err}")
+                            error_msg = str(e)
+                            print(f"[ERROR] Modal evaluation TIMED OUT for Problem ID: {problem_id}, Sample ID: {sample_id}: {error_msg}")
+                            fail_result = KernelExecResult(
+                                compiled=False,
+                                correctness=False,
+                                metadata={"error": f"Timeout after {config.timeout}s: {error_msg}"},
+                                runtime=-1.0,
+                                runtime_stats={},
+                            )
+                            results.append((problem_id, sample_id, fail_result))
                         except Exception as e:
                             # OUTER CATCH: Modal infrastructure or remote execution failures
                             # - GPU attachment failures after retries

--- a/scripts/run_and_check.py
+++ b/scripts/run_and_check.py
@@ -344,46 +344,64 @@ def main(config: ScriptConfig):
 
         with app.run():
             print("[INFO] Evaluating kernel against reference code (MODAL)")
-            # Evaluate kernel against reference code
-            kernel_eval_result = EvalFunc.with_options(
-                gpu=config.gpu
-            )().evaluate_single_sample_src_modal.remote(
-                ref_arch_src=ref_arch_src,
-                kernel_src=kernel_src,
-                configs=config.to_dict(),
-                gpu_arch=gpu_arch
-            )
+            try:
+                # Evaluate kernel against reference code
+                kernel_eval_result = EvalFunc.with_options(
+                    gpu=config.gpu,
+                    timeout=config.timeout,
+                )().evaluate_single_sample_src_modal.remote(
+                    ref_arch_src=ref_arch_src,
+                    kernel_src=kernel_src,
+                    configs=config.to_dict(),
+                    gpu_arch=gpu_arch,
+                )
+            except Exception as e:
+                print(f"[ERROR] Modal evaluation failed: {e}")
+                kernel_eval_result = kernel_eval.KernelExecResult(
+                    compiled=False,
+                    correctness=False,
+                    metadata={"error": str(e)},
+                    runtime=-1.0,
+                    runtime_stats={},
+                )
             kernel_exec_time = kernel_eval_result.runtime
 
-            # Measure baseline time
-            print("[INFO] Measuring reference program time (PyTorch Eager)")
-            ref_time_eager_result = EvalFunc.with_options(
-                gpu=config.gpu
-            )().measure_program_time_modal.remote(
-                ref_arch_src=ref_arch_src,
-                num_trials=config.num_perf_trials,
-                use_torch_compile=False,
-                torch_compile_backend=None,
-                torch_compile_options=None,
-                gpu_arch=gpu_arch,
-                precision=config.precision,
-            )
-            ref_exec_eager_time = ref_time_eager_result.get("mean", None)
+            if kernel_eval_result.correctness:
+                # Measure baseline time
+                print("[INFO] Measuring reference program time (PyTorch Eager)")
+                ref_time_eager_result = EvalFunc.with_options(
+                    gpu=config.gpu,
+                    timeout=config.timeout,
+                )().measure_program_time_modal.remote(
+                    ref_arch_src=ref_arch_src,
+                    num_trials=config.num_perf_trials,
+                    use_torch_compile=False,
+                    torch_compile_backend=None,
+                    torch_compile_options=None,
+                    gpu_arch=gpu_arch,
+                    precision=config.precision,
+                )
+                ref_exec_eager_time = ref_time_eager_result.get("mean", None)
 
-            # Measure Torch Compile time
-            print("[INFO] Measuring reference program time (torch.compile)")
-            ref_time_compile_result = EvalFunc.with_options(
-                gpu=config.gpu
-            )().measure_program_time_modal.remote(
-                ref_arch_src=ref_arch_src,
-                num_trials=config.num_perf_trials,
-                use_torch_compile=True,
-                torch_compile_backend="inductor",
-                torch_compile_options="default",
-                gpu_arch=gpu_arch,
-                precision=config.precision,
-            )
-            ref_exec_compile_time = ref_time_compile_result.get("mean", None)
+                # Measure Torch Compile time
+                print("[INFO] Measuring reference program time (torch.compile)")
+                ref_time_compile_result = EvalFunc.with_options(
+                    gpu=config.gpu,
+                    timeout=config.timeout,
+                )().measure_program_time_modal.remote(
+                    ref_arch_src=ref_arch_src,
+                    num_trials=config.num_perf_trials,
+                    use_torch_compile=True,
+                    torch_compile_backend="inductor",
+                    torch_compile_options="default",
+                    gpu_arch=gpu_arch,
+                    precision=config.precision,
+                )
+                ref_exec_compile_time = ref_time_compile_result.get("mean", None)
+            else:
+                print("[INFO] Skipping reference baseline timing as kernel did not pass correctness.")
+                ref_exec_eager_time = -1.0
+                ref_exec_compile_time = -1.0
 
     print("="*40)
     print(f"[Eval] Kernel eval result: {kernel_eval_result}")


### PR DESCRIPTION
## Why
Faulty or adversarial kernels evaluated on Modal can hang indefinitely, exhaust GPU memory, or corrupt the CUDA context via illegal memory accesses. Because PyTorch raises asynchronous CUDA faults as `RuntimeError`, these errors escaped container decommissioning, leaving contaminated containers active in the worker pool. Furthermore, broken kernels triggered expensive reference baseline timings, wasting cloud GPU minutes.

## Scope
- In `scripts/eval_from_generations.py`:
  - Catch `RuntimeError` in `ModalEvaluator` alongside `torch.cuda.CudaError` and call `modal.experimental.stop_fetching_inputs()` to decommission contaminated containers.
  - Add explicit post-evaluation synchronization and cache clearing.
  - Enforce timeouts on Modal containers via `with_options(timeout=config.timeout)`.
  - Calculate remaining batch deadline in `future.get()` and cancel timed-out containers via `future.cancel(terminate_containers=True)`.
- In `scripts/run_and_check.py`:
  - Enforce timeouts and wrap remote evaluation in `try/except`.
  - Skip PyTorch eager and `torch.compile` reference baseline measurements if the custom kernel failed correctness.

## Blast Radius
Restricted to Modal evaluation scripts (`scripts/eval_from_generations.py` and `scripts/run_and_check.py`). Local evaluation pathways remain unaffected.

## Verification
Syntax verified via `py_compile`. Verified Modal 1.5.5 API compatibility for `FunctionCall.cancel(terminate_containers=True)` and `ModalEvaluator.with_options(gpu=..., timeout=...)`.